### PR TITLE
Update add-to-cart-form.liquid

### DIFF
--- a/snippets/add-to-cart-form.liquid
+++ b/snippets/add-to-cart-form.liquid
@@ -13,7 +13,7 @@
   {% assign has_selected_variant = true %}
 {% endif %}
 
-{% if has_multiple_variants %}
+{% if has_multiple_options or has_multiple_variants %}
   {% include 'get-variants-with-quantity-json' with product: product %}
 {% endif %}
 


### PR DESCRIPTION
The "Shelf/Divider" didn't add to cart for me without this change -- the JSON object with the variants array was not being added to the form HTML